### PR TITLE
Fixed PHP5.4 problem with typecasting array to string

### DIFF
--- a/src/Scribd/API.php
+++ b/src/Scribd/API.php
@@ -254,7 +254,7 @@ class API
         if($result['stat'] == "ok") {
             //This is shifty. Works currently though.
             $result = $this->convert_simplexml_to_array($result);
-            if(urlencode((string)$result) == "%0A%0A" && $this->error == 0) {
+            if(gettype($result) == 'string' && urlencode($result) == "%0A%0A" && $this->error == 0) {
                 $result = "1";
                 return $result;
             } else {


### PR DESCRIPTION
This fixes a problem in PHP 5.4 where it refused to convert an array to a string.

I am not sure in what case `convert_simplexml_to_array` would return 2 line breaks so I hope I have interpreted this function correctly.

Best
Matt
